### PR TITLE
Cleanup flake.nix

### DIFF
--- a/cross-shell.nix
+++ b/cross-shell.nix
@@ -15,7 +15,6 @@ pkgs.mkShell rec {
 
     # Crate dependencies
     cargoDeps.openssl-sys
-    protobuf # required by libp2p
 
     openssh
   ];

--- a/justfile
+++ b/justfile
@@ -16,4 +16,4 @@ gen-bindings:
 
 # Lint solidity files
 sol-lint:
-    solhint --fix 'contracts/**/*.sol'
+    solhint --fix 'contracts/{src,script,test}/**/*.sol'


### PR DESCRIPTION
- Remove some unused env vars, dependencies, code.
- Deduplicate code between rust dev shells.
- Update solhint.
- Run solhint only on some directories to avoid forge submodules.