### PR TITLE
Remove need to change directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,6 +1108,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "escargot"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f474c6844cbd04e783d0f25757583db4f491770ca618bedf2fb01815fc79939"
+dependencies = [
+ "log",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "eth-keystore"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3969,6 +3981,7 @@ dependencies = [
  "clap",
  "commit",
  "contract-bindings",
+ "escargot",
  "ethers",
  "lazy_static",
  "serde",

--- a/justfile
+++ b/justfile
@@ -1,13 +1,11 @@
 default:
     just --list
 
-test:
-    cargo build # build the wallet executable
-    cargo test
+test *args:
+    cargo test {{args}}
 
-nitro-test:
-	# cargo build --release
-	cargo test nitro::test
+nitro-test *args:
+	cargo test nitro::test {{args}}
 
 check:
     pre-commit

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1.0.195", features = ["derive"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.14"
+escargot = "0.5.10"

--- a/wallet/tests/nitro/mod.rs
+++ b/wallet/tests/nitro/mod.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anyhow::Result;
 use async_std::task::sleep;
+use escargot::CargoBuild;
 use ethers::{prelude::*, signers::coins_bip39::English};
 
 use crate::{assert_output_is_receipt, wait_for_condition};
@@ -13,58 +14,85 @@ use contract_bindings::simple_token::SimpleToken;
 
 const NITRO_WORK_DIR: &str = "../tests/nitro/nitro-testnode";
 
+fn stop_and_remove_nitro() {
+    println!("Stopping nitro and removing containers");
+    let output = Command::new("docker")
+        .current_dir(NITRO_WORK_DIR)
+        .arg("compose")
+        .arg("down")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let output = Command::new("docker")
+        .arg("ps")
+        .arg("-aq")
+        .arg("--filter")
+        .arg("label=com.docker.compose.project=nitro-testnode")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let output_str = std::str::from_utf8(&output.stdout).unwrap().trim();
+    if !output_str.is_empty() {
+        let containers = output_str.split("\n").collect::<Vec<_>>();
+        println!("Removing containers {:?}", containers);
+        Command::new("docker")
+            .arg("rm")
+            .args(containers)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+    }
+
+    let output = Command::new("docker")
+        .arg("volume")
+        .arg("ls")
+        .arg("-q")
+        .arg("--filter")
+        .arg("label=com.docker.compose.project=nitro-testnode")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let output_str = std::str::from_utf8(&output.stdout).unwrap().trim();
+    if !output_str.is_empty() {
+        let volumes = output_str.split("\n").collect::<Vec<_>>();
+        println!("Removing volumes {:?}", volumes);
+        let output = Command::new("docker")
+            .arg("volume")
+            .arg("rm")
+            .args(volumes)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+    }
+}
+
 struct Cleanup;
 impl Drop for Cleanup {
     fn drop(&mut self) {
-        println!("drop it!");
-        Command::new("docker")
-            .current_dir(NITRO_WORK_DIR)
-            .arg("compose")
-            .arg("down")
-            .output()
-            .unwrap();
-
-        let output = Command::new("docker")
-            .arg("ps")
-            .arg("-a")
-            .arg("-q")
-            .output()
-            .unwrap();
-
-        let stdout = std::str::from_utf8(&output.stdout).unwrap();
-        let containers = stdout.trim();
-
-        Command::new("docker")
-            .arg("rm")
-            .arg(containers)
-            .output()
-            .unwrap();
+        stop_and_remove_nitro();
     }
+}
+
+fn run_wallet() -> Command {
+    CargoBuild::new()
+        .bin("wallet")
+        .current_release()
+        .current_target()
+        .run()
+        .unwrap()
+        .command()
 }
 
 #[async_std::test]
 async fn test() -> Result<()> {
+    stop_and_remove_nitro();
     let _teardown = Cleanup;
 
-    let mut path = std::env::current_dir()?;
-    path.push("target");
-    path.push("nix");
-    let mut wallet_dir = path.clone();
-    wallet_dir.push("release");
-
-    // build the release first
-    Command::new("cargo")
-        .arg("build")
-        .arg("--release")
-        .arg("--target-dir")
-        .arg(path.as_path())
-        .output()?;
-
     // Sanity test to assert that we can locate the binary.
-    let output = Command::new("./wallet")
-        .arg("--help")
-        .current_dir(&wallet_dir)
-        .output()?;
+    let output = run_wallet().arg("--help").output()?;
     dbg!(&output);
     assert!(output.status.success());
 
@@ -94,16 +122,17 @@ async fn test() -> Result<()> {
     let client = SignerMiddleware::new(provider, wallet);
     let addr = client.address();
 
-    // Check the fund
+    // Check the funding
     let _ = wait_for_condition(
         || async {
+            println!("checking if nitro RPC is ready and client is funded");
             match client.get_balance(addr, None).await {
                 Ok(num) => {
-                    println!("querying the balance: {:?}", num);
+                    println!("current balance: {num}");
                     num > 0.into()
                 }
                 Err(e) => {
-                    eprintln!("failed to get balance: {:?}", e);
+                    println!("failed to query balance: {e}");
                     false
                 }
             }
@@ -114,12 +143,20 @@ async fn test() -> Result<()> {
     .await;
 
     // Wait for the testnode running completely
+    let min_block_num = 50.into();
     let l2_is_good = wait_for_condition(
         || async {
+            println!("waiting for nitro block number > {min_block_num}");
             let output = client.get_block_number().await;
             match output {
-                Ok(b) => b > 50.into(),
-                Err(_) => false,
+                Ok(b) => {
+                    println!("block number: {b}");
+                    b > min_block_num
+                }
+                Err(_) => {
+                    println!("failed to get block number");
+                    false
+                }
             }
         },
         Duration::from_secs(5),
@@ -147,16 +184,15 @@ async fn test() -> Result<()> {
     .await;
     assert!(commitment_task_is_good);
 
-    let balance_output = Command::new("./wallet")
+    let balance_output = run_wallet()
         .arg("balance")
         .env("MNEMONIC", mnemonic)
         .env("ROLLUP_RPC_URL", nitro_rpc)
         .env("ACCOUNT_INDEX", index.to_string())
-        .current_dir(&wallet_dir)
         .output()?;
     assert!(balance_output.status.success());
 
-    let transfer_output = Command::new("./wallet")
+    let transfer_output = run_wallet()
         .arg("transfer")
         .arg("--to")
         .arg(format!("0x{:x}", Address::random()))
@@ -165,12 +201,11 @@ async fn test() -> Result<()> {
         .env("MNEMONIC", mnemonic)
         .env("ROLLUP_RPC_URL", nitro_rpc)
         .env("ACCOUNT_INDEX", index.to_string())
-        .current_dir(&wallet_dir)
         .output()?;
 
     assert_output_is_receipt(transfer_output);
     let dummy_address = format!("0x{:x}", Address::from_slice(&[1u8; 20]));
-    let transfer_with_invalid_builder = Command::new("./wallet")
+    let transfer_with_invalid_builder = run_wallet()
         .arg("transfer")
         .arg("--to")
         .arg(dummy_address)
@@ -181,14 +216,13 @@ async fn test() -> Result<()> {
         .env("ROLLUP_RPC_URL", nitro_rpc)
         .env("ACCOUNT_INDEX", index.to_string())
         .env("BUILDER_ADDRESS", format!("0x{:x}", Address::zero()))
-        .current_dir(&wallet_dir)
         .output()?;
     assert!(!transfer_with_invalid_builder.status.success());
 
     let dummy_address = format!("0x{:x}", Address::from_slice(&[2u8; 20]));
 
     let valid_builder_address = "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f";
-    let transfer_with_valid_builder = Command::new("./wallet")
+    let transfer_with_valid_builder = run_wallet()
         .arg("transfer")
         .arg("--to")
         .arg(dummy_address)
@@ -199,7 +233,6 @@ async fn test() -> Result<()> {
         .env("ROLLUP_RPC_URL", nitro_rpc)
         .env("ACCOUNT_INDEX", index.to_string())
         .env("BUILDER_ADDRESS", valid_builder_address)
-        .current_dir(&wallet_dir)
         .output()?;
 
     assert!(transfer_with_valid_builder.status.success());
@@ -217,7 +250,7 @@ async fn test() -> Result<()> {
 
     let erc20_addr = "0xB7Fc0E52ec06F125F3afebA199248c79F71c2e3a";
 
-    let output = Command::new("./wallet")
+    let output = run_wallet()
         .arg("mint-erc20")
         .arg("--contract-address")
         .arg(erc20_addr)
@@ -228,12 +261,11 @@ async fn test() -> Result<()> {
         .env("MNEMONIC", mnemonic)
         .env("ROLLUP_RPC_URL", nitro_rpc)
         .env("ACCOUNT_INDEX", index.to_string())
-        .current_dir(&wallet_dir)
         .output()?;
 
     assert!(output.status.success());
 
-    let output = Command::new("./wallet")
+    let output = run_wallet()
         .arg("mint-erc20")
         .arg("--contract-address")
         .arg(erc20_addr)
@@ -246,24 +278,22 @@ async fn test() -> Result<()> {
         .env("ROLLUP_RPC_URL", nitro_rpc)
         .env("ACCOUNT_INDEX", index.to_string())
         .env("BUILDER_ADDRESS", valid_builder_address)
-        .current_dir(&wallet_dir)
         .output()?;
 
     assert!(output.status.success());
 
-    let output = Command::new("./wallet")
+    let output = run_wallet()
         .arg("balance-erc20")
         .arg("--contract-address")
         .arg(erc20_addr)
         .env("MNEMONIC", mnemonic)
         .env("ROLLUP_RPC_URL", nitro_rpc)
         .env("ACCOUNT_INDEX", index.to_string())
-        .current_dir(&wallet_dir)
         .output()?;
 
     assert!(output.status.success());
 
-    let output = Command::new("./wallet")
+    let output = run_wallet()
         .arg("transfer-erc20")
         .arg("--contract-address")
         .arg(erc20_addr)
@@ -274,12 +304,11 @@ async fn test() -> Result<()> {
         .env("MNEMONIC", mnemonic)
         .env("ROLLUP_RPC_URL", nitro_rpc)
         .env("ACCOUNT_INDEX", index.to_string())
-        .current_dir(&wallet_dir)
         .output()?;
 
     assert!(output.status.success());
 
-    let output = Command::new("./wallet")
+    let output = run_wallet()
         .arg("transfer-erc20")
         .arg("--contract-address")
         .arg(erc20_addr)
@@ -292,7 +321,6 @@ async fn test() -> Result<()> {
         .env("ROLLUP_RPC_URL", nitro_rpc)
         .env("ACCOUNT_INDEX", index.to_string())
         .env("BUILDER_ADDRESS", valid_builder_address)
-        .current_dir(&wallet_dir)
         .output()?;
 
     assert!(output.status.success());


### PR DESCRIPTION
Using the escargot crate allows to find the binaries with specified target and features.

Improve the docker cleanup:

- Filter containers and volumes by docker-compose project.
- Remove containers and volumes from project.

Run the cleanup at the start of the test (and at the end).

This allows to run the test even if the current state of the system contains containers or volumes.