### PR TITLE
Support reading config from file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-serde-derive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4b7d643cbdc3a4eb0b5db8b9844ab2002bc4be44c1244db5cd27df8e594c125"
+dependencies = [
+ "clap",
+ "clap-serde-proc",
+ "serde",
+]
+
+[[package]]
+name = "clap-serde-proc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6725cfcf906f158cdad4ca9a2a426133b36a3f91b5da2b971f8b956823ef55e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,7 +1952,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -3840,14 +3862,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.7",
+ "toml_edit 0.22.11",
 ]
 
 [[package]]
@@ -3894,9 +3916,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.7"
+version = "0.22.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+checksum = "fb686a972ccef8537b39eead3968b0e8616cb5040dbb9bba93007c8e07c9215f"
 dependencies = [
  "indexmap",
  "serde",
@@ -4050,6 +4072,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -4126,6 +4149,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "clap",
+ "clap-serde-derive",
  "commit",
  "contract-bindings",
  "dotenv",
@@ -4134,6 +4158,7 @@ dependencies = [
  "lazy_static",
  "reqwest",
  "serde",
+ "toml",
  "url",
 ]
 

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,7 @@
+MNEMONIC="test test test test test test test test test test test junk"
+rollup_rpc_url="http://127.0.0.1:8547"
+account_index=0
+[command.transfer]
+to="0x9e0869fecdd81281a77e84c931456bbc39fe2144"
+amount=10
+guaranteed_by_builder=false

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -8,13 +8,15 @@ anyhow = "^1.0"
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
 async-trait = "0.1.77"
 clap = { version = "4.4", features = ["derive", "env"] }
+clap-serde-derive = "0.2.1"
 commit = { git = "https://github.com/EspressoSystems/commit" }
 contract-bindings = { path = "../contract-bindings" }
 ethers = "2.0"
 lazy_static = "1.4"
 reqwest = { version = "0.11.26", features = ["json"] }
 serde = { version = "1.0.195", features = ["derive"] }
-url = "2.5.0"
+toml = "0.8.12"
+url = { version = "2.5.0", features = ["serde"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -66,6 +66,7 @@ enum Commands {
         #[clap(long, default_value_t = false)]
         guaranteed_by_builder: bool,
     },
+    #[serde(alias = "transfer_erc20")]
     TransferErc20 {
         #[clap(long)]
         contract_address: Address,
@@ -83,10 +84,12 @@ enum Commands {
     #[default]
     #[serde(alias = "balance")]
     Balance,
+    #[serde(alias = "balance_erc20")]
     BalanceErc20 {
         #[clap(long)]
         contract_address: Address,
     },
+    #[serde(alias = "mint_erc20")]
     MintErc20 {
         #[clap(long)]
         contract_address: Address,

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -19,7 +19,7 @@ use wallet::EspressoWallet;
 #[command(author, version, about)]
 struct Args {
     /// Config file
-    #[arg(short, long = "config", default_value = "../config.toml")]
+    #[arg(short, long = "config", default_value = "config.toml")]
     config_path: std::path::PathBuf,
 
     /// Rest of arguments

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -121,7 +121,6 @@ async fn main() {
         Config::from(&mut cli.config)
     };
 
-    dbg!(&config);
     let provider = Provider::<Http>::try_from(&config.rollup_rpc_url).unwrap();
     let id = provider.get_chainid().await.unwrap();
     let wallet = EspressoWallet::new(

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -1,18 +1,36 @@
 mod builder;
 mod wallet;
-
 use builder::get_builder_address;
-use clap::{Parser, Subcommand};
+use clap::Subcommand;
+use clap_serde_derive::{
+    clap::{self, Parser},
+    ClapSerde,
+};
 use ethers::{
     providers::{Http, Middleware, Provider},
     types::{Address, U256},
 };
+use serde::{Deserialize, Serialize};
+use std::fs;
 use url::Url;
 use wallet::EspressoWallet;
 
-#[derive(Parser, Debug)]
-pub struct Cli {
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Args {
+    /// Config file
+    #[arg(short, long = "config", default_value = "../config.toml")]
+    config_path: std::path::PathBuf,
+
+    /// Rest of arguments
+    #[command(flatten)]
+    pub config: <Config as ClapSerde>::Opt,
+}
+
+#[derive(ClapSerde, Debug, Deserialize, Serialize)]
+pub struct Config {
     #[clap(long, env = "MNEMONIC")]
+    #[serde(alias = "mnemonic", alias = "MNEMONIC")]
     mnemonic: String,
 
     #[clap(long, env = "ROLLUP_RPC_URL")]
@@ -29,12 +47,14 @@ pub struct Cli {
     #[clap(long, env = "ACCOUNT_INDEX", default_value = "0")]
     account_index: u32,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
+    #[serde(alias = "command")]
     commands: Commands,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Default, Subcommand, Debug, Deserialize, Serialize)]
 enum Commands {
+    #[serde(alias = "transfer")]
     Transfer {
         /// hex string of the target address
         #[clap(long)]
@@ -60,6 +80,8 @@ enum Commands {
         #[clap(long, default_value_t = false)]
         guaranteed_by_builder: bool,
     },
+    #[default]
+    #[serde(alias = "balance")]
     Balance,
     BalanceErc20 {
         #[clap(long)]
@@ -83,13 +105,26 @@ enum Commands {
 
 #[async_std::main]
 async fn main() {
-    let cli = Cli::parse();
-    let provider = Provider::<Http>::try_from(&cli.rollup_rpc_url).unwrap();
+    let mut cli = Args::parse();
+    // Get config file
+    let config = if let Ok(f) = fs::read_to_string(&cli.config_path) {
+        // parse toml
+        match toml::from_str::<Config>(&f) {
+            Ok(config) => config.merge(&mut cli.config),
+            Err(err) => panic!("Error in configuration file:\n{}", err),
+        }
+    } else {
+        // If there is no config file return only config parsed from clap
+        Config::from(&mut cli.config)
+    };
+
+    dbg!(&config);
+    let provider = Provider::<Http>::try_from(&config.rollup_rpc_url).unwrap();
     let id = provider.get_chainid().await.unwrap();
     let wallet = EspressoWallet::new(
-        cli.mnemonic,
-        cli.account_index,
-        cli.rollup_rpc_url,
+        config.mnemonic,
+        config.account_index,
+        config.rollup_rpc_url,
         id.as_u64(),
     );
     if let Err(e) = wallet {
@@ -97,15 +132,18 @@ async fn main() {
     }
     let wallet = wallet.unwrap();
 
-    match &cli.commands {
+    match &config.commands {
         Commands::Transfer {
             to,
             amount,
             guaranteed_by_builder,
         } => {
-            let builder_addr =
-                maybe_get_builder_addr(guaranteed_by_builder, cli.builder_url, cli.builder_addr)
-                    .await;
+            let builder_addr = maybe_get_builder_addr(
+                guaranteed_by_builder,
+                config.builder_url,
+                config.builder_addr,
+            )
+            .await;
             let receipt = wallet
                 .transfer(*to, U256::from(*amount), builder_addr)
                 .await
@@ -122,9 +160,12 @@ async fn main() {
             to,
             guaranteed_by_builder,
         } => {
-            let builder_addr =
-                maybe_get_builder_addr(guaranteed_by_builder, cli.builder_url, cli.builder_addr)
-                    .await;
+            let builder_addr = maybe_get_builder_addr(
+                guaranteed_by_builder,
+                config.builder_url,
+                config.builder_addr,
+            )
+            .await;
             let receipt = wallet
                 .transfer_erc20(*contract_address, *to, U256::from(*amount), builder_addr)
                 .await
@@ -141,9 +182,12 @@ async fn main() {
             to,
             guaranteed_by_builder,
         } => {
-            let builder_addr =
-                maybe_get_builder_addr(guaranteed_by_builder, cli.builder_url, cli.builder_addr)
-                    .await;
+            let builder_addr = maybe_get_builder_addr(
+                guaranteed_by_builder,
+                config.builder_url,
+                config.builder_addr,
+            )
+            .await;
             let receipt = wallet
                 .mint_erc20(*contract_address, *to, U256::from(*amount), builder_addr)
                 .await;
@@ -176,6 +220,7 @@ mod test {
     use ethers::{types::Address, utils::Anvil};
 
     static MNEMONIC: &str = "test test test test test test test test test test test junk";
+
     #[test]
     fn test_bin_balance() -> anyhow::Result<()> {
         let anvil = Anvil::new().chain_id(1u64).spawn();


### PR DESCRIPTION
Since there are quite a few CLI arguments that are not expected to change much (mnemonic, builder URL, ...) it might be easier for the users and for us, when writing documentation, if those parameters could be read from a file instead of having to set an env var or specifying them on the command line.

Maybe we can use https://crates.io/crates/clap-serde-derive/ to parse a toml file.