### PR TITLE
block on request to builder API

### DIFF
--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -15,7 +15,7 @@ directories = "5.0.1"
 ethers = "2.0"
 git-version = "0.3.9"
 lazy_static = "1.4"
-reqwest = { version = "0.11.26", features = ["json"] }
+reqwest = { version = "0.11.26", features = ["json", "blocking"] }
 serde = { version = "1.0.195", features = ["derive"] }
 sysinfo = { version = "0.30.12", default-features = false }
 toml = "0.8.12"

--- a/wallet/src/builder.rs
+++ b/wallet/src/builder.rs
@@ -8,13 +8,11 @@ struct EthKey {
     address: String,
 }
 
-pub async fn get_builder_address(url: Url) -> Address {
+pub fn get_builder_address(url: Url) -> Address {
     let url = url.join("block_info/builderaddress").unwrap();
-    let body = reqwest::get(url)
-        .await
+    let body = reqwest::blocking::get(url)
         .unwrap()
         .json::<EthKey>()
-        .await
         .unwrap();
 
     body.address.parse::<Address>().unwrap()

--- a/wallet/src/builder.rs
+++ b/wallet/src/builder.rs
@@ -1,3 +1,5 @@
+use std::{thread::sleep, time::Duration};
+
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -10,10 +12,17 @@ struct EthKey {
 
 pub fn get_builder_address(url: Url) -> Address {
     let url = url.join("block_info/builderaddress").unwrap();
-    let body = reqwest::blocking::get(url)
-        .unwrap()
-        .json::<EthKey>()
-        .unwrap();
-
-    body.address.parse::<Address>().unwrap()
+    for _ in 0..5 {
+        if let Ok(body) = reqwest::blocking::get(url.clone()) {
+            return body
+                .json::<EthKey>()
+                .unwrap()
+                .address
+                .parse::<Address>()
+                .unwrap();
+        } else {
+            sleep(Duration::from_millis(400))
+        }
+    }
+    panic!("Error: Failed to retrieve address from builder!");
 }

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -243,8 +243,7 @@ async fn main() -> anyhow::Result<()> {
                 guaranteed_by_builder,
                 config.builder_url,
                 config.builder_addr,
-            )
-            .await;
+            );
             let receipt = wallet
                 .transfer(*to, U256::from(*amount), builder_addr)
                 .await?;
@@ -271,8 +270,7 @@ async fn main() -> anyhow::Result<()> {
                 guaranteed_by_builder,
                 config.builder_url,
                 config.builder_addr,
-            )
-            .await;
+            );
             let receipt = wallet
                 .transfer_erc20(*contract_address, *to, U256::from(*amount), builder_addr)
                 .await?;
@@ -292,8 +290,7 @@ async fn main() -> anyhow::Result<()> {
                 guaranteed_by_builder,
                 config.builder_url,
                 config.builder_addr,
-            )
-            .await;
+            );
             let receipt = wallet
                 .mint_erc20(*contract_address, *to, amount.map(U256::from), builder_addr)
                 .await;
@@ -307,14 +304,14 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn maybe_get_builder_addr(
+fn maybe_get_builder_addr(
     guaranteed_by_builder: &bool,
     builder_url: Option<Url>,
     builder_addr: Option<Address>,
 ) -> Option<Address> {
     if *guaranteed_by_builder {
         if let Some(url) = builder_url {
-            return Some(get_builder_address(url).await);
+            return Some(get_builder_address(url));
         };
         builder_addr
     } else {

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -309,14 +309,9 @@ fn maybe_get_builder_addr(
     builder_url: Option<Url>,
     builder_addr: Option<Address>,
 ) -> Option<Address> {
-    if *guaranteed_by_builder {
-        if let Some(url) = builder_url {
-            return Some(get_builder_address(url));
-        };
-        builder_addr
-    } else {
-        None
-    }
+    guaranteed_by_builder
+        .then(|| builder_url.map(get_builder_address).or(builder_addr))
+        .flatten()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
B/c we don't need the async and it makes the code cleaner. Also add retry to HTTP request to builder (closes #48).