### PR TITLE
Add commands to generate config, deploy token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ node_modules/
 contracts/cache
 contracts/out
 contracts/broadcast/*/31337
+
+config.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4152,6 +4161,7 @@ dependencies = [
  "clap-serde-derive",
  "commit",
  "contract-bindings",
+ "directories",
  "dotenv",
  "escargot",
  "ethers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,6 +4158,7 @@ dependencies = [
  "lazy_static",
  "reqwest",
  "serde",
+ "tempfile",
  "toml",
  "url",
 ]

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,0 @@
-MNEMONIC="test test test test test test test test test test test junk"
-rollup_rpc_url="http://127.0.0.1:8547"
-account_index=0
-[command.transfer]
-to="0x9e0869fecdd81281a77e84c931456bbc39fe2144"
-amount=10
-guaranteed_by_builder=false

--- a/config.toml.default
+++ b/config.toml.default
@@ -1,0 +1,4 @@
+mnemonic = "test test test test test test test test test test test junk"
+account_index = 0
+rollup_rpc_url = "http://127.0.0.1:8547" # TODO
+builder_url = "https://builder.sepolia.testnet.espresso.network"

--- a/config.toml.local
+++ b/config.toml.local
@@ -1,0 +1,5 @@
+# For convenience config file for local development
+mnemonic = "test test test test test test test test test test test junk"
+account_index = 0
+rollup_rpc_url = "http://localhost:8545"
+builder_url = "http://localhost:41003"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "4.4", features = ["derive", "env"] }
 clap-serde-derive = "0.2.1"
 commit = { git = "https://github.com/EspressoSystems/commit" }
 contract-bindings = { path = "../contract-bindings" }
+directories = "5.0.1"
 ethers = "2.0"
 lazy_static = "1.4"
 reqwest = { version = "0.11.26", features = ["json"] }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -22,3 +22,4 @@ url = { version = "2.5.0", features = ["serde"] }
 assert_cmd = "2.0.14"
 dotenv = "0.15.0"
 escargot = "0.5.10"
+tempfile = "3.10.1"

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -7,13 +7,19 @@ use clap_serde_derive::{
     ClapSerde,
 };
 use ethers::{
+    core::rand::thread_rng,
     providers::{Http, Middleware, Provider},
+    signers::{
+        coins_bip39::{English, Mnemonic},
+        MnemonicBuilder, Signer as _,
+    },
     types::{Address, U256},
 };
 use serde::{Deserialize, Serialize};
 use std::fs;
 use url::Url;
 use wallet::EspressoWallet;
+use wallet::DEV_MNEMONIC;
 
 #[derive(Parser)]
 #[command(author, version, about)]
@@ -29,12 +35,14 @@ struct Args {
 
 #[derive(ClapSerde, Debug, Deserialize, Serialize)]
 pub struct Config {
-    #[clap(long, env = "MNEMONIC")]
+    #[clap(long, env = "MNEMONIC", default_value = DEV_MNEMONIC)]
     #[serde(alias = "mnemonic", alias = "MNEMONIC")]
-    mnemonic: String,
+    pub mnemonic: String,
 
+    /// The url for the rollup rpc.
     #[clap(long, env = "ROLLUP_RPC_URL")]
-    rollup_rpc_url: String,
+    #[default(Url::parse("http://localhost:8545").unwrap())]
+    rollup_rpc_url: Url,
 
     /// The url for fetching the builder address.
     #[clap(long, env = "BUILDER_URL")]
@@ -48,13 +56,15 @@ pub struct Config {
     account_index: u32,
 
     #[command(subcommand)]
-    #[serde(alias = "command")]
+    #[serde(skip)]
     commands: Commands,
 }
 
 #[derive(Default, Subcommand, Debug, Deserialize, Serialize)]
 enum Commands {
-    #[serde(alias = "transfer")]
+    /// Initialize the config file with a new mnemonic.
+    Init,
+    /// Transfer Eth to another address.
     Transfer {
         /// hex string of the target address
         #[clap(long)]
@@ -66,7 +76,15 @@ enum Commands {
         #[clap(long, default_value_t = false)]
         guaranteed_by_builder: bool,
     },
-    #[serde(alias = "transfer_erc20")]
+    /// Deploy ERC20 token.
+    DeployErc20 {
+        #[clap(long, default_value = "TestToken")]
+        name: String,
+
+        #[clap(long, default_value = "TOK")]
+        symbol: String,
+    },
+    /// Transfer ERC20 tokens to another address.
     TransferErc20 {
         #[clap(long)]
         contract_address: Address,
@@ -81,58 +99,85 @@ enum Commands {
         #[clap(long, default_value_t = false)]
         guaranteed_by_builder: bool,
     },
+    /// Check Eth balance.
     #[default]
-    #[serde(alias = "balance")]
     Balance,
-    #[serde(alias = "balance_erc20")]
+    /// Check ERC20 token balance.
     BalanceErc20 {
         #[clap(long)]
         contract_address: Address,
     },
-    #[serde(alias = "mint_erc20")]
+    /// Mint ERC20 tokens to own account.
     MintErc20 {
         #[clap(long)]
         contract_address: Address,
 
         #[clap(long)]
-        amount: u64,
+        amount: Option<u64>,
 
-        /// hex string of the target address
+        /// hex string of the target address, default to own address
         #[clap(long)]
-        to: Address,
+        to: Option<Address>,
 
         #[clap(long, default_value_t = false)]
         guaranteed_by_builder: bool,
     },
 }
 
+fn exit_err(msg: impl AsRef<str>, err: impl core::fmt::Display) -> ! {
+    eprintln!("{}: {err}", msg.as_ref());
+    std::process::exit(1);
+}
+
 #[async_std::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     let mut cli = Args::parse();
     // Get config file
     let config = if let Ok(f) = fs::read_to_string(&cli.config_path) {
         // parse toml
         match toml::from_str::<Config>(&f) {
             Ok(config) => config.merge(&mut cli.config),
-            Err(err) => panic!("Error in configuration file:\n{}", err),
+            Err(err) => {
+                // This is a user error print the hopefully helpful error
+                // message without backtrace and exit.
+                exit_err("Error in configuration file", err);
+            }
         }
     } else {
         // If there is no config file return only config parsed from clap
         Config::from(&mut cli.config)
     };
 
-    let provider = Provider::<Http>::try_from(&config.rollup_rpc_url).unwrap();
-    let id = provider.get_chainid().await.unwrap();
+    // Run the init command first because config values required by other
+    // commands are not present.
+    if let Commands::Init = config.commands {
+        let mut config = toml::from_str::<Config>(include_str!("../../config.toml.default"))?;
+        // Generate a new mnemonic for the user.
+        let mnemonic = Mnemonic::<English>::new(&mut thread_rng());
+        config.mnemonic = mnemonic.to_phrase();
+        let wallet = MnemonicBuilder::<English>::default()
+            .phrase(config.mnemonic.as_ref())
+            .build()?;
+        println!("Address of new wallet: {:#x}", wallet.address());
+
+        // Save config file to cli.config_path
+        fs::write(&cli.config_path, toml::to_string(&config)?)?;
+        println!("Config file saved to {}", cli.config_path.display());
+        return Ok(());
+    }
+
+    let provider = Provider::<Http>::try_from(&config.rollup_rpc_url.to_string())?;
+    let id = provider
+        .get_chainid()
+        .await
+        .unwrap_or_else(|err| exit_err("failed to get chain ID from rollup RPC", err));
     let wallet = EspressoWallet::new(
         config.mnemonic,
         config.account_index,
-        config.rollup_rpc_url,
+        config.rollup_rpc_url.to_string(),
         id.as_u64(),
     );
-    if let Err(e) = wallet {
-        panic!("failed to create a wallet: {}", e);
-    }
-    let wallet = wallet.unwrap();
+    let wallet = wallet.unwrap_or_else(|err| exit_err("failed to create a wallet", err));
 
     match &config.commands {
         Commands::Transfer {
@@ -148,13 +193,16 @@ async fn main() {
             .await;
             let receipt = wallet
                 .transfer(*to, U256::from(*amount), builder_addr)
-                .await
-                .unwrap();
+                .await?;
             println!("{:?}", receipt);
         }
         Commands::Balance => {
-            let result = wallet.balance().await.unwrap();
+            let result = wallet.balance().await?;
             println!("{}", result);
+        }
+        Commands::DeployErc20 { name, symbol } => {
+            let contract = wallet.deploy_erc20(name, symbol).await?;
+            println!("ERC20 token deployed at {:#x}", contract.address());
         }
         Commands::TransferErc20 {
             contract_address,
@@ -170,12 +218,11 @@ async fn main() {
             .await;
             let receipt = wallet
                 .transfer_erc20(*contract_address, *to, U256::from(*amount), builder_addr)
-                .await
-                .unwrap();
+                .await?;
             println!("{:?}", receipt);
         }
         Commands::BalanceErc20 { contract_address } => {
-            let balance = wallet.balance_erc20(*contract_address).await.unwrap();
+            let balance = wallet.balance_erc20(*contract_address).await?;
             println!("{:?}", balance.to_string());
         }
         Commands::MintErc20 {
@@ -191,14 +238,16 @@ async fn main() {
             )
             .await;
             let receipt = wallet
-                .mint_erc20(*contract_address, *to, U256::from(*amount), builder_addr)
+                .mint_erc20(*contract_address, *to, amount.map(U256::from), builder_addr)
                 .await;
             match receipt {
                 Ok(r) => println!("{:?}", r),
-                Err(e) => panic!("got error: {:?}", e),
+                Err(err) => exit_err("failed to get receipt", err),
             }
         }
-    }
+        _ => {} // The init command is handled before this match.
+    };
+    Ok(())
 }
 
 async fn maybe_get_builder_addr(
@@ -218,16 +267,15 @@ async fn maybe_get_builder_addr(
 
 #[cfg(test)]
 mod test {
+    use crate::wallet::DEV_MNEMONIC;
     use assert_cmd::Command;
     use ethers::{types::Address, utils::Anvil};
-
-    static MNEMONIC: &str = "test test test test test test test test test test test junk";
 
     #[test]
     fn test_bin_balance() -> anyhow::Result<()> {
         let anvil = Anvil::new().chain_id(1u64).spawn();
-        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-        cmd.env("MNEMONIC", MNEMONIC)
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
+        cmd.env("MNEMONIC", DEV_MNEMONIC)
             .env("ROLLUP_RPC_URL", anvil.endpoint())
             .arg("balance")
             .assert()
@@ -241,16 +289,48 @@ mod test {
         let anvil = Anvil::new().chain_id(1u64).spawn();
         // Include builder address to catch parsing errors.
         let valid_builder_address = "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f";
-        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-        cmd.env("MNEMONIC", MNEMONIC)
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
+        cmd.env("MNEMONIC", DEV_MNEMONIC)
             .env("ROLLUP_RPC_URL", anvil.endpoint())
             .env("BUILDER_ADDRESS", valid_builder_address)
             .arg("transfer")
             .arg("--amount")
             .arg("1")
             .arg("--to")
-            .arg(format!("{:x}", Address::random()))
+            .arg(format!("{:#x}", Address::random()))
             .arg("--guaranteed-by-builder")
+            .assert()
+            .success();
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_generate_config_file() -> anyhow::Result<()> {
+        let tmpdir = tempfile::tempdir()?;
+        let config_path = tmpdir.path().join("config.toml");
+
+        assert!(!config_path.exists());
+
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
+        cmd.arg("-c")
+            .arg(&config_path)
+            .arg("init")
+            .assert()
+            .success();
+
+        assert!(config_path.exists());
+
+        let anvil = Anvil::new().chain_id(1u64).spawn();
+
+        // Check that we can query the balance with the config file.
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
+        cmd.arg("-c")
+            .arg(&config_path)
+            // Overwrite the rpc value in the config file so that we can get a response.
+            .arg("--rollup-rpc-url")
+            .arg(anvil.endpoint())
+            .arg("balance")
             .assert()
             .success();
 

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -35,7 +35,8 @@ struct Args {
 
 #[derive(ClapSerde, Debug, Deserialize, Serialize)]
 pub struct Config {
-    #[clap(long, env = "MNEMONIC", default_value = DEV_MNEMONIC)]
+    #[default(DEV_MNEMONIC.to_string())]
+    #[clap(long, env = "MNEMONIC")]
     #[serde(alias = "mnemonic", alias = "MNEMONIC")]
     pub mnemonic: String,
 


### PR DESCRIPTION
Add command to generate a config file.

This config file should contain the right values for RPC urls so that it can be used in production. It generates a new mnemonic so we have less to document about how to do that. The docs will just have to tell the requests funds from the faucet(s) for this address.

Add a command to deploy a token. This makes deployment and documentation easier because users can easily deploy their own tokens to experiment with and don't need us to provide them.

Apologies there are also a bunch of miscellaneous changes that I ran into while working on this.

Try not to show tracebacks to users (unless there are internal errors) and instead show a simple and clear error message and exit with non-zero exit code.

Support a few more defaults when minting: mint to the owners address by default, mint 10000 tokens by default.

Set polling interval to 2 seconds, 7 seconds makes sense for Ethereum mainnet but for our sequencer it is on the slow side because that window may contain several blocks.

Leave commands out of config file. I think it doesn't really make sense to have them in there because users are expected to switch between commands often.

Closes #49 
