### PR TITLE
Let's detach from the shell

### DIFF
--- a/scripts/run-sequencer
+++ b/scripts/run-sequencer
@@ -4,4 +4,4 @@ set -euo pipefail
 cd tests/nitro/nitro-testnode
 docker compose pull --ignore-pull-failures
 
-./test-node.bash --init --espresso --latest-espresso-image
+./test-node.bash --init --espresso --latest-espresso-image --detach


### PR DESCRIPTION
This way we can keep everything in a single terminal. The caller knows
the services are healthy when the shell is returned to them.