### PR TITLE
Increase funded timeout

### DIFF
--- a/wallet/tests/nitro/mod.rs
+++ b/wallet/tests/nitro/mod.rs
@@ -181,7 +181,7 @@ async fn test() -> Result<()> {
             }
         },
         Duration::from_secs(5),
-        Duration::from_secs(300),
+        Duration::from_secs(1000),
     )
     .await;
     assert!(funded);


### PR DESCRIPTION
I need a longer timeout for this to pass locally. I guess the
important thing is that it passes in CI but it seems that a common
debugging scenario would be to run this locally, and it causes
confusion if it fails. Also if this succeeds before the timeout it
continues anyway so there is not much of a downside.